### PR TITLE
Fix Port Detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-windsurf-auth",


### PR DESCRIPTION
**Issue:** Windsurf spawns language server on random port on startup on linux, here is my approach.
**Note:** Changes are Linux focused but contain logic for MacOS and Windows.

**Changes:**
* Fix Port Detection: Now scans Windsurf logs to find the actual dynamic port, rather than assuming a fixed offset.
* Improve Process Discovery: Refined process matching to correctly identify the active Windsurf language server and avoid false positives.
* Add Logging: Introduced file-based logging to ~/.local/share/opencode/windsurf-plugin.log to help debug connection issues.

> Crafted with Claude Opus 4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added timestamped local logging and richer startup/connection visibility to help diagnose proxy and service startup.
  * Improved detection and port discovery for the Windsurf language server for more reliable connectivity.

* **New Features**
  * Added CodeiumPlugin as an alternate public entry point for the plugin.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->