### PR TITLE
Use the correct model list command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ After saving the config:
 
 ```bash
 opencode models windsurf                                        # confirm models appear under windsurf/
-opencode chat --model=windsurf/claude-4.5-opus "Hello"          # quick smoke test
+opencode run --model=windsurf/claude-4.5-opus "Hello"          # quick smoke test
 ```
 
 Keep Windsurf running and signed in—credentials are fetched live from the IDE process.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Add the following to your Opencode config (typically `~/.config/opencode/config.
 After saving the config:
 
 ```bash
-opencode models list                                            # confirm models appear under windsurf/
+opencode models windsurf                                        # confirm models appear under windsurf/
 opencode chat --model=windsurf/claude-4.5-opus "Hello"          # quick smoke test
 ```
 


### PR DESCRIPTION
``opencode model list`` is not a real command or subsequently has been removed in newer Opencode versions to it has been replaced with ``opencode models windsurf`` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated post-configuration verification: instruct users to run `opencode models windsurf` to confirm available models and use `opencode run --model=...` (replacing the previous quick smoke-test command) for a quick test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rsvedant/opencode-windsurf-auth/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->