### PR TITLE
Auto pull models from windsurf + Link Lieance in README

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "./"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ bun test
 
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Opencode plugin for Windsurf/Codeium authentication - use Windsurf models in Ope
 ## Features
 
 - OpenAI-compatible `/v1/chat/completions` interface with streaming SSE
+- Automatic model discovery - Models are auto-pulled from Windsurf
 - Automatic credential discovery (CSRF token, port, API key)
 - Transparent REST↔gRPC translation over HTTP/2
 - Zero extra auth prompts when Windsurf is running
@@ -34,7 +35,7 @@ bun add opencode-windsurf-auth@beta
 
 ## Opencode Configuration
 
-Add the following to your Opencode config (typically `~/.config/opencode/config.json`). The plugin starts a local proxy server on port 42100 (falls back to a random free port and updates `chat.params` automatically). The full model list with variants is in `opencode_config_example.json`; thinking vs non-thinking are separate models, while variants are only for performance tiers (low/high/xhigh/etc.).
+Add the following to your Opencode config (typically `~/.config/opencode/config.json`). The plugin starts a local proxy server on port 42100 (falls back to a random free port and updates `chat.params` automatically).
 
 ```json
 {
@@ -45,44 +46,6 @@ Add the following to your Opencode config (typically `~/.config/opencode/config.
       "npm": "@ai-sdk/openai-compatible",
       "options": {
         "baseURL": "http://127.0.0.1:42100/v1"
-      },
-      "models": {
-        "claude-opus-4.7": {
-          "name": "Claude Opus 4.7 (Windsurf)",
-          "limit": { "context": 1000000, "output": 128000 },
-          "variants": {
-            "low": {}, "medium": {}, "high": {}, "xhigh": {}, "max": {},
-            "low-fast": {}, "medium-fast": {}, "high-fast": {}, "xhigh-fast": {}, "max-fast": {}
-          }
-        },
-        "gpt-5.5": {
-          "name": "GPT 5.5 (Windsurf)",
-          "limit": { "context": 1050000, "output": 128000 },
-          "variants": {
-            "none": {}, "low": {}, "medium": {}, "high": {}, "xhigh": {},
-            "none-priority": {}, "low-priority": {}, "medium-priority": {}, "high-priority": {}, "xhigh-priority": {}
-          }
-        },
-        "deepseek-v4": {
-          "name": "DeepSeek V4 (Windsurf)",
-          "limit": { "context": 1000000, "output": 384000 }
-        },
-        "kimi-k2.6": {
-          "name": "Kimi K2.6 (Windsurf)",
-          "limit": { "context": 262144, "output": 262144 }
-        },
-        "gemini-3.5-flash": {
-          "name": "Gemini 3.5 Flash (Windsurf)",
-          "limit": { "context": 1048576, "output": 65536 },
-          "variants": { "minimal": {}, "low": {}, "medium": {}, "high": {} }
-        },
-        "claude-opus-4.6": {
-          "name": "Claude Opus 4.6 (Windsurf)",
-          "limit": { "context": 1000000, "output": 128000 },
-          "variants": {
-            "thinking": {}, "1m": {}, "thinking-1m": {}, "fast": {}, "thinking-fast": {}
-          }
-        }
       }
     }
   }

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "opencode-windsurf-auth",

--- a/opencode_config_example.json
+++ b/opencode_config_example.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "DEPRECATED: Manual model configuration is no longer needed. Models are auto-discovered from Windsurf via GetUserStatus. Remove the 'models' section and let the plugin discover models dynamically.",
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "opencode-windsurf-auth"

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,6 +24,7 @@ import {
   getModelVariants,
   resolveModel,
 } from './plugin/models.js';
+import { discoverModels, type OpenCodeModel } from './plugin/model-discovery.js';
 import { PLUGIN_ID } from './constants.js';
 
 // ============================================================================
@@ -653,25 +654,41 @@ async function ensureWindsurfProxyServer(): Promise<string> {
 
       // Models endpoint
       if (url.pathname === '/v1/models' || url.pathname === '/models') {
-        const models = getCanonicalModels();
+        // Use dynamic model discovery from Windsurf instead of static catalog
+        const discoveredModels = await discoverModels();
+        
+        let models: OpenCodeModel[];
+        
+        if (discoveredModels.length > 0) {
+          // Use dynamically discovered models
+          models = discoveredModels;
+        } else {
+          // Fall back to static catalog if discovery fails
+          models = getCanonicalModels().map((id) => {
+            const variants = getModelVariants(id);
+            return {
+              id,
+              name: `${id} (Windsurf)`,
+              limit: { context: 200000, output: 8192 },
+              ...(variants ? { variants } : {}),
+            };
+          });
+        }
+        
         return new Response(
           JSON.stringify({
             object: 'list',
-            data: models.map((id) => {
-              const variants = getModelVariants(id);
+            data: models.map((model) => {
+              const variantList = model.variants 
+                ? Object.keys(model.variants).map((v) => ({ id: v }))
+                : undefined;
+              
               return {
-                id,
+                id: model.id,
                 object: 'model',
                 created: Math.floor(Date.now() / 1000),
                 owned_by: 'windsurf',
-                ...(variants
-                  ? {
-                      variants: Object.entries(variants).map(([name, meta]) => ({
-                        id: name,
-                        description: meta.description,
-                      })),
-                    }
-                  : {}),
+                ...(variantList && variantList.length > 0 ? { variants: variantList } : {}),
               };
             }),
           }),

--- a/src/plugin/cascade-client.ts
+++ b/src/plugin/cascade-client.ts
@@ -29,6 +29,8 @@ import {
   encodeVarintField,
 } from './protobuf.js';
 
+export { encodeMessage };
+
 function encodeTimestampBody(): number[] {
   const now = Date.now();
   const seconds = Math.floor(now / 1000);
@@ -62,7 +64,7 @@ let nextRequestId = BigInt(Date.now());
  *   17 extension_path (empty), 24 device_fingerprint (empty), 25 trigger_id,
  *   26 plan_name, 28 ide_type.
  */
-function buildMetadata(creds: WindsurfCredentials, sessionId: string): number[] {
+export function buildMetadata(creds: WindsurfCredentials, sessionId: string): number[] {
   const fields = getMetadataFields();
   const requestId = nextRequestId++;
   const triggerId = crypto.randomUUID();
@@ -89,7 +91,7 @@ function buildMetadata(creds: WindsurfCredentials, sessionId: string): number[] 
 // gRPC unary helper
 // ============================================================================
 
-function unaryRpc(
+export function unaryRpc(
   creds: WindsurfCredentials,
   rpcName: string,
   payload: Buffer,
@@ -198,7 +200,7 @@ function wrapError(rpcName: string, err: Error): WindsurfError {
 
 import { decodeVarint as decodeVarintAt } from './protobuf.js';
 
-function walkFields(
+export function walkFields(
   buf: Buffer,
   visit: (field: number, wire: number, value: Buffer | bigint) => void
 ): void {
@@ -559,6 +561,121 @@ const STEADY_TICKS_BEFORE_DONE = 4;
 const MAX_CONSECUTIVE_POLL_ERRORS = 3;
 const MAX_POLL_ERRORS_PER_WINDOW = 5;
 const POLL_ERROR_WINDOW_SIZE = 15;
+
+// ============================================================================
+// Model Discovery via GetUserStatus
+// ============================================================================
+
+export interface ModelConfig {
+  label: string;
+  modelUid: string;
+  modelEnum?: number;
+  isNew: boolean;
+  contextLimit?: number;
+  outputLimit?: number;
+}
+
+/**
+ * Parse output limit from Field 32 text description.
+ * 
+ * Field 32 contains text like "OutputA 1M tokens" or "OutputC 200K tokens".
+ * This function extracts the number and converts it to tokens.
+ */
+function parseOutputLimit(text: string): number | undefined {
+  // Look for "Output" followed by a number with unit (K, M, B)
+  const match = text.match(/Output\s*[^\d]*?(\d+(?:\.\d+)?)(K|M|B|T)?/i);
+  if (!match) return undefined;
+  
+  const value = parseFloat(match[1]);
+  const unit = (match[2] || '').toUpperCase();
+  
+  const multipliers: Record<string, number> = {
+    '': 1,
+    'K': 1000,
+    'M': 1000000,
+    'B': 1000000000,
+    'T': 1000000000000,
+  };
+  
+  const multiplier = multipliers[unit] || 1;
+  return Math.floor(value * multiplier);
+}
+
+/**
+ * Fetch the live model list from Windsurf via GetUserStatus.
+ * 
+ * Returns the client_model_configs[] array which contains:
+ * - field 1: label (display name)
+ * - field 2: model_or_alias (submessage with optional model enum)
+ * - field 15: is_new (bool)
+ * - field 22: model_uid (string) - the actual identifier
+ */
+export async function getUserStatus(
+  creds: WindsurfCredentials,
+  signal?: AbortSignal
+): Promise<ModelConfig[]> {
+  const meta = buildMetadata(creds, crypto.randomUUID());
+  const payload = Buffer.from(encodeMessage(1, meta));
+
+  const body = await unaryRpc(creds, 'GetUserStatus', payload, 10_000, signal);
+
+  const configs: ModelConfig[] = [];
+  
+  // Walk the response to find user data (field 1) → model configs (field 33)
+  walkFields(body, (field, wire, value) => {
+    if (field === 1 && wire === 2 && Buffer.isBuffer(value)) {
+      // Inside user data, find model configs (field 33)
+      walkFields(value, (nestedField, nestedWire, nestedValue) => {
+        if (nestedField === 33 && nestedWire === 2 && Buffer.isBuffer(nestedValue)) {
+          // Inside model configs, find client_model_configs (field 1, repeated)
+          walkFields(nestedValue, (configField, configWire, configValue) => {
+            if (configField === 1 && configWire === 2 && Buffer.isBuffer(configValue)) {
+              // Parse individual client_model_config entry
+              const config: ModelConfig = {
+                label: '',
+                modelUid: '',
+                isNew: false,
+              };
+
+              walkFields(configValue, (entryField, entryWire, entryValue) => {
+                if (entryField === 1 && entryWire === 2 && Buffer.isBuffer(entryValue)) {
+                  config.label = entryValue.toString('utf8');
+                } else if (entryField === 2 && entryWire === 2 && Buffer.isBuffer(entryValue)) {
+                  // model_or_alias submessage - extract model enum (field 1)
+                  walkFields(entryValue, (aliasField, aliasWire, aliasValue) => {
+                    if (aliasField === 1 && aliasWire === 0) {
+                      config.modelEnum = Number(aliasValue as bigint);
+                    }
+                  });
+                } else if (entryField === 15 && entryWire === 0) {
+                  config.isNew = (entryValue as bigint) === 1n;
+                } else if (entryField === 18 && entryWire === 0) {
+                  // context limit (field 18)
+                  config.contextLimit = Number(entryValue as bigint);
+                } else if (entryField === 22 && entryWire === 2 && Buffer.isBuffer(entryValue)) {
+                  config.modelUid = entryValue.toString('utf8');
+                } else if (entryField === 32 && entryWire === 2 && Buffer.isBuffer(entryValue)) {
+                  // Field 32 contains text descriptions with output limits
+                  const text = entryValue.toString('utf8');
+                  const outputLimit = parseOutputLimit(text);
+                  if (outputLimit && (!config.outputLimit || outputLimit > config.outputLimit)) {
+                    config.outputLimit = outputLimit;
+                  }
+                }
+              });
+
+              if (config.modelUid) {
+                configs.push(config);
+              }
+            }
+          });
+        }
+      });
+    }
+  });
+
+  return configs;
+}
 
 export async function* streamCascadeChat(
   creds: WindsurfCredentials,

--- a/src/plugin/model-discovery.ts
+++ b/src/plugin/model-discovery.ts
@@ -1,0 +1,375 @@
+/**
+ * Model Discovery - Auto-pull models from Windsurf
+ * 
+ * Fetches live model configs from Windsurf via GetUserStatus and transforms
+ * them into OpenCode-compatible format with names, context limits, and variants.
+ */
+
+import { getUserStatus, type ModelConfig as WindsurfModelConfig } from './cascade-client.js';
+import { getCredentials } from './auth.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface OpenCodeModel {
+  id: string;
+  name: string;
+  limit: {
+    context: number;
+    output: number;
+  };
+  variants?: Record<string, {}>;
+}
+
+// Extend Windsurf's ModelConfig with variantName for internal use
+interface ModelConfig extends WindsurfModelConfig {
+  variantName?: string;
+}
+
+// ============================================================================
+// Context Limit Defaults
+// ============================================================================
+
+// Default context limits by model family (when not provided by Windsurf)
+
+// If for some reason these fail please open a issue - Openlyst
+const DEFAULT_CONTEXT_LIMITS: Record<string, { context: number; output: number }> = {
+  // Claude models
+  'claude-opus-4': { context: 1000000, output: 128000 },
+  'claude-opus-4.6': { context: 1000000, output: 128000 },
+  'claude-opus-4.7': { context: 1000000, output: 128000 },
+  'claude-sonnet-4': { context: 200000, output: 64000 },
+  'claude-sonnet-4.6': { context: 200000, output: 64000 },
+  'claude-4.5': { context: 200000, output: 64000 },
+  'claude-4': { context: 200000, output: 32000 },
+  'claude-3.7': { context: 200000, output: 64000 },
+  'claude-3.5': { context: 200000, output: 8192 },
+  'claude-3': { context: 200000, output: 4096 },
+  
+  // GPT models
+  'gpt-5': { context: 400000, output: 128000 },
+  'gpt-5.5': { context: 1050000, output: 128000 },
+  'gpt-5.4': { context: 1050000, output: 128000 },
+  'gpt-5.3': { context: 400000, output: 128000 },
+  'gpt-5.2': { context: 400000, output: 128000 },
+  'gpt-5.1': { context: 400000, output: 128000 },
+  'gpt-4.1': { context: 1047576, output: 32768 },
+  'gpt-4o': { context: 128000, output: 16384 },
+  'gpt-4': { context: 128000, output: 8192 },
+  
+  // O-series
+  'o3': { context: 200000, output: 100000 },
+  'o3-pro': { context: 200000, output: 100000 },
+  'o4-mini': { context: 200000, output: 100000 },
+  
+  // Gemini
+  'gemini-3': { context: 1048576, output: 65536 },
+  'gemini-2.5': { context: 1048576, output: 65536 },
+  'gemini-2': { context: 1048576, output: 8192 },
+  
+  // DeepSeek
+  'deepseek-v4': { context: 1000000, output: 384000 },
+  'deepseek-v3': { context: 163840, output: 16384 },
+  'deepseek-r1': { context: 163840, output: 163840 },
+  
+  // SWE
+  'swe-1.6': { context: 200000, output: 8192 },
+  'swe-1.5': { context: 200000, output: 8192 },
+  
+  // Others
+  'llama-3': { context: 131072, output: 16384 },
+  'qwen-3': { context: 262144, output: 65536 },
+  'qwen-2.5': { context: 32768, output: 32768 },
+  'grok': { context: 131072, output: 8192 },
+  'glm-5': { context: 204800, output: 131072 },
+  'glm-4': { context: 204800, output: 131072 },
+  'minimax': { context: 204800, output: 131072 },
+  'kimi': { context: 262144, output: 65536 },
+};
+
+// Default fallback for unknown models
+const DEFAULT_LIMITS = { context: 200000, output: 8192 };
+
+// ============================================================================
+// Caching
+// ============================================================================
+
+let cachedModels: OpenCodeModel[] | null = null;
+let cacheTime = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// ============================================================================
+// Model ID Transformation
+// ============================================================================
+
+/**
+ * Convert Windsurf model_uid to canonical OpenCode model ID.
+ * 
+ * Examples:
+ * - "claude-opus-4-7-medium" -> "claude-opus-4.7"
+ * - "swe-1-6" -> "swe-1.6"
+ * - "MODEL_CLAUDE_4_5_OPUS" -> "claude-4.5-opus"
+ */
+function modelUidToId(modelUid: string): string {
+  // Handle legacy enum-style UIDs
+  if (modelUid.startsWith('MODEL_')) {
+    const name = modelUid.slice(7); // Remove "MODEL_"
+    return name
+      .toLowerCase()
+      .replace(/_/g, '-');
+  }
+  
+  // Known variant suffixes to stop at
+  const variantSuffixes = [
+    'fast', 'thinking', 'low', 'medium', 'high', 'xhigh', 'max',
+    'minimal', 'lite', 'priority', 'codex', 'pro', 'flash', 'mini'
+  ];
+  
+  // Find where the variant starts
+  const parts = modelUid.split('-');
+  let versionEnd = parts.length;
+  
+  for (let i = 0; i < parts.length; i++) {
+    if (variantSuffixes.includes(parts[i])) {
+      versionEnd = i;
+      break;
+    }
+  }
+  
+  // Only convert version numbers in the base part
+  const basePart = parts.slice(0, versionEnd).join('-');
+  const converted = basePart
+    .replace(/(\d)-(\d)/g, '$1.$2')  // 4-7 -> 4.7
+    .replace(/(\d)-(\d)/g, '$1.$2');  // Apply twice for cases like 1-6-5
+  
+  return converted;
+}
+
+/**
+ * Extract base model family from model ID for context limit lookup.
+ * 
+ * Examples:
+ * - "claude-opus-4.7" -> "claude-opus-4"
+ * - "gpt-5.4" -> "gpt-5"
+ * - "swe-1.6" -> "swe-1"
+ */
+function getModelFamily(modelId: string): string {
+  // Extract the base name before version numbers
+  const match = modelId.match(/^([a-z-]+-\d+\.?\d*)/);
+  if (match) {
+    const base = match[1];
+    // For versioned models, return the family (e.g., gpt-5.4 -> gpt-5)
+    const familyMatch = base.match(/^([a-z-]+-\d+)\.?/);
+    if (familyMatch) {
+      return familyMatch[1];
+    }
+    return base;
+  }
+  
+  // Fallback: return first two segments
+  const parts = modelId.split('-');
+  if (parts.length >= 2) {
+    return `${parts[0]}-${parts[1]}`;
+  }
+  
+  return modelId;
+}
+
+/**
+ * Get context limits for a model based on its family.
+ */
+function getContextLimits(modelId: string): { context: number; output: number } {
+  const family = getModelFamily(modelId);
+  
+  // Try exact family match first
+  if (DEFAULT_CONTEXT_LIMITS[family]) {
+    return DEFAULT_CONTEXT_LIMITS[family];
+  }
+  
+  // Try prefix match
+  for (const [key, limits] of Object.entries(DEFAULT_CONTEXT_LIMITS)) {
+    if (modelId.startsWith(key)) {
+      return limits;
+    }
+  }
+  
+  return DEFAULT_LIMITS;
+}
+
+/**
+ * Generate a smart name from the model label.
+ * 
+ * Examples:
+ * - "Claude Opus 4.7 Medium" -> "Claude Opus 4.7 Medium (Windsurf)"
+ * - "SWE 1.6" -> "SWE 1.6 (Windsurf)"
+ */
+function generateSmartName(label: string): string {
+  return `${label} (Windsurf)`;
+}
+
+/**
+ * Extract variant name from model_uid by comparing it to the base pattern.
+ * 
+ * Parses variant indicators from the model_uid string.
+ * Examples:
+ * - "claude-opus-4-7-medium" -> "medium"
+ * - "claude-opus-4-7-medium-fast" -> "medium-fast"
+ * - "swe-1-6-fast" -> "fast"
+ * - "gpt-5-5-low" -> "low"
+ */
+function extractVariantName(modelUid: string, modelId: string): string | undefined {
+  // Convert modelId back to uid format to find the base pattern
+  // e.g., "claude-opus-4.7" -> "claude-opus-4-7"
+  const basePattern = modelId.replace(/\./g, '-');
+  
+  // If model_uid starts with basePattern, the rest is the variant
+  if (modelUid.startsWith(basePattern) && modelUid !== basePattern) {
+    const variant = modelUid.slice(basePattern.length);
+    // Remove leading dash if present
+    return variant.startsWith('-') ? variant.slice(1) : variant;
+  }
+  
+  return undefined;
+}
+
+/**
+ * Group models by their base model ID and collect variants dynamically.
+ * 
+ * This function takes all discovered models and groups them by their canonical ID,
+ * collecting all variant names from the model_uid strings.
+ */
+function groupModelsByBase(models: ModelConfig[]): Map<string, ModelConfig[]> {
+  const groups = new Map<string, ModelConfig[]>();
+  
+  for (const model of models) {
+    const modelId = modelUidToId(model.modelUid);
+    const variantName = extractVariantName(model.modelUid, modelId);
+    
+    // Store the variant name in the model config for later use
+    if (variantName) {
+      model.variantName = variantName;
+    }
+    
+    if (!groups.has(modelId)) {
+      groups.set(modelId, []);
+    }
+    groups.get(modelId)!.push(model);
+  }
+  
+  return groups;
+}
+
+/**
+ * Extract variants for a model by looking at all models with the same base ID.
+ * 
+ * This is fully dynamic - it doesn't rely on the hardcoded VARIANT_CATALOG.
+ */
+function extractVariants(modelId: string, allModels: ModelConfig[]): Record<string, {}> | undefined {
+  const groups = groupModelsByBase(allModels);
+  const group = groups.get(modelId);
+  
+  if (!group || group.length <= 1) {
+    // No variants found (only one model with this base ID)
+    return undefined;
+  }
+  
+  // Collect all variant names from the group
+  const variants: Record<string, {}> = {};
+  
+  for (const model of group) {
+    const variantName = model.variantName;
+    if (variantName) {
+      variants[variantName] = {};
+    }
+  }
+  
+  // If we have at least one variant, return them
+  if (Object.keys(variants).length > 0) {
+    return variants;
+  }
+  
+  return undefined;
+}
+
+// ============================================================================
+// Main Discovery Function
+// ============================================================================
+
+/**
+ * Fetch and transform live models from Windsurf into OpenCode format.
+ * 
+ * This calls GetUserStatus to get the current model list, then transforms
+ * each entry into the OpenCode config format with:
+ * - id: canonical model identifier
+ * - name: human-readable display name
+ * - limit: context and output token limits
+ * - variants: available model variants (if any)
+ * 
+ * Results are cached for 5 minutes to avoid repeated RPC calls.
+ */
+export async function discoverModels(): Promise<OpenCodeModel[]> {
+  const now = Date.now();
+  
+  // Return cached results if still valid
+  if (cachedModels && (now - cacheTime) < CACHE_TTL_MS) {
+    return cachedModels;
+  }
+  
+  try {
+    const creds = getCredentials();
+    const configs = await getUserStatus(creds);
+    
+    // Transform configs into OpenCode format
+    const models: OpenCodeModel[] = [];
+    const seenIds = new Set<string>();
+    
+    for (const config of configs) {
+      const modelId = modelUidToId(config.modelUid);
+      
+      // Skip duplicates (keep first occurrence)
+      if (seenIds.has(modelId)) {
+        continue;
+      }
+      seenIds.add(modelId);
+      
+      // Use context limit from Windsurf if available, otherwise use defaults
+      const contextLimit = config.contextLimit || getContextLimits(modelId).context;
+      const outputLimit = config.outputLimit || getContextLimits(modelId).output;
+      const variants = extractVariants(modelId, configs);
+      
+      models.push({
+        id: modelId,
+        name: generateSmartName(config.label || modelId),
+        limit: {
+          context: contextLimit,
+          output: outputLimit,
+        },
+        ...(variants && { variants }),
+      });
+    }
+    
+    // Sort by ID for consistent ordering
+    models.sort((a, b) => a.id.localeCompare(b.id));
+    
+    // Cache the results
+    cachedModels = models;
+    cacheTime = now;
+    
+    return models;
+  } catch (error) {
+    // If discovery fails, fall back to empty list
+    // (The static catalog in models.ts will still work for chat)
+    return [];
+  }
+}
+
+/**
+ * Clear the model discovery cache.
+ * 
+ * Call this after Windsurf restarts or when you need fresh data.
+ */
+export function clearModelCache(): void {
+  cachedModels = null;
+  cacheTime = 0;
+}

--- a/src/plugin/models.ts
+++ b/src/plugin/models.ts
@@ -80,7 +80,7 @@ type ModelCatalogEntry = {
 // Variant Catalog
 // ==========================================================================
 
-const VARIANT_CATALOG: Record<string, ModelCatalogEntry> = {
+export const VARIANT_CATALOG: Record<string, ModelCatalogEntry> = {
   // Claude thinking variants
   'claude-3.7-sonnet': {
     id: 'claude-3.7-sonnet',


### PR DESCRIPTION
This change will auto pull any model from windsurf. Allowing users to not have to write a huge config for each model they want to use for Opencode. This change also really helps when a new model comes out from Windsurf.

This change also updates the README with the new info about dynamic loading as well as linking the MIT license to the file.